### PR TITLE
Fix spec typo and usage token assigning

### DIFF
--- a/docs/ws/spec.md
+++ b/docs/ws/spec.md
@@ -10,7 +10,7 @@ To connect to our websocket start by establishing a connection to `wss://listen.
 * `OP 1` - Receive data (receive)
 * `OP 2` - Receive requested data (send)
 * `OP 9` - Heartbeat (send)
-* `OP 10` - Heartbeat acknowledge (recieve)
+* `OP 10` - Heartbeat acknowledge (receive)
 
 ## Authenticating
 

--- a/docs/ws/spec.md
+++ b/docs/ws/spec.md
@@ -8,7 +8,7 @@ To connect to our websocket start by establishing a connection to `wss://listen.
 
 * `OP 0` - Authentication (send/receive)
 * `OP 1` - Receive data (receive)
-* `OP 2` - Receive requested data (send)
+* `OP 2` - Request data (send)
 * `OP 9` - Heartbeat (send)
 * `OP 10` - Heartbeat acknowledge (receive)
 

--- a/docs/ws/usage.md
+++ b/docs/ws/usage.md
@@ -6,7 +6,7 @@ A simple JavaScript implementation could be as follows:
 
 ```js
 const WebSocket = require('ws');
-const jwt = null // Or the user's saved JWT;
+const jwt = null; // Or the user's saved JWT
 let ws;
 
 class SocketConnection {
@@ -29,7 +29,7 @@ class SocketConnection {
 		ws = new WebSocket('wss://listen.moe/gateway');
 		ws.onopen = () => {
 			clearInterval(this.sendHeartbeat);
-			const token = `Bearer ${jwt}` || '';
+			const token = jwt ? `Bearer ${jwt}` : '';
 			ws.send(JSON.stringify({ op: 0, d: { auth: token } }));
 		};
 		ws.onmessage = message => {


### PR DESCRIPTION
PR just fixes a simple "recieve" typo in the spec and turns the variable assigning of the token const into a ternary to avoid it turning out as "Bearer null" when the jwt variable is set as such.